### PR TITLE
Fix to H2 properties to allow multiple connections

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -1,6 +1,6 @@
 logging.level.sql=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-spring.datasource.url=jdbc:h2:file:./target/db-development
+spring.datasource.url=jdbc:h2:file:./target/db-development;AUTO_SERVER=TRUE
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true


### PR DESCRIPTION
### Close #9 

This update fixes the H2 database configuration to allow multiple connections during development.

Previously, H2 was running in exclusive mode, which caused errors when multiple parts of the application tried to access the database at the same time.

The fix adds `AUTO_SERVER=TRUE` to the datasource URL so Spring Boot can open concurrent H2 connections without failing.

Deployed at:
https://courses-dev-chenchangwang.dokku-03.cs.ucsb.edu