### PR TITLE
Replace backup link with updated url, Fix backup link logic

### DIFF
--- a/frontend/src/main/components/Nav/Footer.jsx
+++ b/frontend/src/main/components/Nav/Footer.jsx
@@ -29,26 +29,17 @@ export default function Footer(systemInfo) {
           </a>
           . Check out the source code on
           {space}
-          {systemInfo.systemInfo && (
-            <a
-              data-testid="footer-source-code-link"
-              href={systemInfo.systemInfo.sourceRepo}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              GitHub
-            </a>
-          )}
-          {!systemInfo.systemInfo && (
-            <a
-              data-testid="footer-source-code-link"
-              href={"https://github.com/ucsb-cs156/proj-courses"}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              GitHub
-            </a>
-          )}
+          <a
+            data-testid="footer-source-code-link"
+            href={
+              systemInfo?.systemInfo?.sourceRepo ||
+              "https://github.com/ucsb-cs156/proj-courses"
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </a>
           ! This is not an official source of UCSB course information. An
           official source can be found
           {space}

--- a/frontend/src/tests/components/Nav/Footer.test.jsx
+++ b/frontend/src/tests/components/Nav/Footer.test.jsx
@@ -46,4 +46,30 @@ describe("Footer tests", () => {
       "mocklink",
     );
   });
+
+  test("Backup sourceRepo renders correctly when systemInfo is undefined", async () => {
+    render(<Footer />);
+    expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
+      "href",
+      "https://github.com/ucsb-cs156/proj-courses",
+    );
+  });
+
+  test("Backup sourceRepo renders correctly when systemInfo.systemInfo is undefined", async () => {
+    let systemInfo = { systemInfo: undefined };
+    render(<Footer systemInfo={systemInfo} />);
+    expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
+      "href",
+      "https://github.com/ucsb-cs156/proj-courses",
+    );
+  });
+
+  test("Backup sourceRepo renders correctly when systemInfo.systemInfo.sourceRepo is undefined", async () => {
+    let systemInfo = { systemInfo: {} };
+    render(<Footer systemInfo={systemInfo} />);
+    expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
+      "href",
+      "https://github.com/ucsb-cs156/proj-courses",
+    );
+  });
 });


### PR DESCRIPTION
Closes #23 

Deployed at https://courses-dev-adamw3455-footer-link.dokku-03.cs.ucsb.edu/

The previous footer backup source code link was https://github.com/ucsb-cs156-f22/f22-5pm-courses, which is an outdated, quarter specific link. I corrected it to the main courses repo https://github.com/ucsb-cs156/proj-courses.

The footer also did not correctly render the backup source code link, which I fixed by improving the undefined/missing sourceRepo detection logic.

Screenshot of correct HTML component/href attribute with blocked systemInfo API call:
<img width="919" height="519" alt="image" src="https://github.com/user-attachments/assets/51223754-a19c-4538-8c99-69d75a8177e4" />
