### PR TITLE
Remove SectionsTable Eslint Exception

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.jsx
+++ b/frontend/src/main/components/Sections/SectionsTable.jsx
@@ -20,9 +20,7 @@ import {
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import AddToScheduleModal from "main/components/PersonalSchedules/AddToScheduleModal";
 
-/* eslint-disable react-refresh/only-export-components*/
-
-export const objectToAxiosParams = (data) => {
+const objectToAxiosParams = (data) => {
   return {
     url: "/api/courses/post",
     method: "POST",
@@ -33,7 +31,7 @@ export const objectToAxiosParams = (data) => {
   };
 };
 
-export const onSuccess = (response) => {
+const onSuccess = (response) => {
   if (response.length < 3) {
     toast(
       `New course Created - id: ${response[0].id} enrollCd: ${response[0].enrollCd}`,
@@ -45,7 +43,7 @@ export const onSuccess = (response) => {
   }
 };
 
-export const onError = (error) => {
+const onError = (error) => {
   console.error("onError: error=", error);
   const message =
     error.response.data?.message ||
@@ -53,7 +51,6 @@ export const onError = (error) => {
   toast.error(message);
 };
 
-/* eslint-enable react-refresh/only-export-components*/
 export default function SectionsTable({ sections, schedules = [] }) {
   if (!(schedules instanceof Array)) {
     throw new Error("schedules prop must be an array");

--- a/frontend/src/tests/components/Sections/SectionsTable.loggedIn.test.jsx
+++ b/frontend/src/tests/components/Sections/SectionsTable.loggedIn.test.jsx
@@ -3,11 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import SectionsTable, {
-  onError,
-  onSuccess,
-} from "main/components/Sections/SectionsTable";
-import { objectToAxiosParams } from "main/components/Sections/SectionsTable";
+import SectionsTable from "main/components/Sections/SectionsTable";
 
 import primaryFixtures from "fixtures/primaryFixtures";
 
@@ -53,14 +49,29 @@ vi.mock("main/utils/currentUser", async () => ({
 }));
 
 describe("SectionsTable tests", () => {
-  describe("objectToAxiosParams", () => {
-    it("should return the correct axios parameters", () => {
-      const data = {
-        enrollCd: 12345,
-        psId: 15,
-      };
+  describe("objectToAxiosParams wired into useBackendMutation", () => {
+    it("passes a function that builds correct axios params", () => {
+      const queryClient = new QueryClient();
+      const mockMutate = vi.fn();
 
-      const result = objectToAxiosParams(data);
+      useBackendMutation.mockReturnValue({ mutate: mockMutate });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <SectionsTable
+              sections={primaryFixtures.f24_math_lowerDiv}
+              schedules={personalScheduleFixtures.oneF24PersonalSchedule}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      expect(useBackendMutation).toHaveBeenCalledTimes(1);
+
+      const [axiosParamsFn] = useBackendMutation.mock.calls[0];
+
+      const result = axiosParamsFn({ enrollCd: 12345, psId: 15 });
 
       expect(result).toEqual({
         url: "/api/courses/post",
@@ -73,48 +84,65 @@ describe("SectionsTable tests", () => {
     });
   });
 
-  describe("onSuccess", () => {
-    it("should display a success message for new course creation", () => {
+  describe("onSuccess passed into useBackendMutation", () => {
+    const queryClient = new QueryClient();
+
+    const renderAndGetCallbacks = () => {
+      const mockMutate = vi.fn();
+      useBackendMutation.mockReturnValue({ mutate: mockMutate });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <SectionsTable
+              sections={primaryFixtures.f24_math_lowerDiv}
+              schedules={personalScheduleFixtures.oneF24PersonalSchedule}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      expect(useBackendMutation).toHaveBeenCalled();
+      const [, callbacks] = useBackendMutation.mock.calls[0]; // { onSuccess, onError }
+      return callbacks;
+    };
+
+    it("shows toast for new course creation", () => {
+      const { onSuccess } = renderAndGetCallbacks();
+
       const response = [{ id: 1, enrollCd: "12345" }];
       onSuccess(response);
+
       expect(toast).toHaveBeenCalledWith(
         "New course Created - id: 1 enrollCd: 12345",
       );
     });
 
-    it("should display a success message for course replacement", () => {
+    it("shows toast for course replacement", () => {
+      const { onSuccess } = renderAndGetCallbacks();
+
       const response = [
         { enrollCd: "12345" },
         { enrollCd: "67890" },
         { enrollCd: "54321" },
       ];
       onSuccess(response);
+
       expect(toast).toHaveBeenCalledWith(
         "Course 12345 replaced old section 54321 with new section 67890",
       );
     });
   });
 
-  describe("onError", () => {
-    beforeEach(() => {
+  describe("onError passed into useBackendMutation", () => {
+    const queryClient = new QueryClient();
+
+    const renderAndGetOnError = () => {
       restoreConsole = mockConsole();
-      useBackendMutation.mockClear();
-    });
 
-    afterEach(() => {
-      restoreConsole();
-      vi.resetAllMocks();
-    });
+      const mockMutate = vi.fn();
+      useBackendMutation.mockReturnValue({ mutate: mockMutate });
 
-    it("should display an error message with the response data", () => {
-      // arrange
-
-      const queryClient = new QueryClient();
-      useBackendMutation.mockReturnValue({
-        mutate: vi.fn(),
-      });
-
-      // Render a component that will call useBackendMutation
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter>
@@ -123,32 +151,37 @@ describe("SectionsTable tests", () => {
         </QueryClientProvider>,
       );
 
+      const [, callbacks] = useBackendMutation.mock.calls[0];
+      return callbacks.onError;
+    };
+
+    afterEach(() => {
+      restoreConsole();
+      vi.resetAllMocks();
+    });
+
+    it("displays error message from response.data.message", () => {
+      const onError = renderAndGetOnError();
+
       const error = {
         response: {
           data: { message: "An error occurred" },
         },
       };
 
-      // act
       onError(error);
-
-      // assert
-      expect(useBackendMutation).toHaveBeenCalledTimes(1);
-      expect(useBackendMutation).toHaveBeenCalledWith(
-        objectToAxiosParams,
-        { onSuccess, onError },
-        [],
-      );
 
       expect(toast.error).toHaveBeenCalledWith("An error occurred");
       expect(console.error).toHaveBeenCalledWith("onError: error=", error);
     });
 
-    it("should display a generic error message when no response data is available", () => {
-      const error = {
-        response: {},
-      };
+    it("falls back to generic error message when no response data", () => {
+      const onError = renderAndGetOnError();
+
+      const error = { response: {} };
+
       onError(error);
+
       expect(toast.error).toHaveBeenCalledWith(
         "An unexpected error occurred adding the schedule: " +
           JSON.stringify(error),


### PR DESCRIPTION
### Closes #15

Removes the ESLint exception related to `react-refresh/only-export-components` in `SectionsTable.jsx` and refactors the file so it fully complies with Vite’s React Refresh rules.
The helper functions (`objectToAxiosParams`, `onSuccess`, and `onError`) are now internal to the component, and the test suite has been updated accordingly.

The previous version exported multiple helper functions from the same file as a React component, which caused conflicts with hot-reload behavior under Vite.

In this update, these helpers are converted into local functions, and the tests have been rewritten to retrieve mutation callbacks through `useBackendMutation.mock.calls` instead of importing them directly.

Deployed at:
https://courses-dev-chenchangwang.dokku-03.cs.ucsb.edu