### PR TITLE
Joshua Add User Pagination Backend Endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UsersController.java
@@ -10,10 +10,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,11 +23,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/admin/users")
 @RestController
 public class UsersController extends ApiController {
-  @Autowired
-  UserRepository userRepository;
+  @Autowired UserRepository userRepository;
 
-  @Autowired
-  ObjectMapper mapper;
+  @Autowired ObjectMapper mapper;
 
   @Operation(summary = "Get a list of all users")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -40,11 +38,29 @@ public class UsersController extends ApiController {
 
   @Operation(summary = "Get a list of all users with pages")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @GetMapping(params = { "page", "pageSize", "sortDirection" })
+  @GetMapping(params = {"page", "pageSize", "sortDirection"})
   public Iterable<User> usersPaged(
-      @Parameter(name = "page", description = "what page of the data", example = "0", required = true) @RequestParam int page,
-      @Parameter(name = "pageSize", description = "size of each page", example = "5", required = true) @RequestParam int pageSize,
-      @Parameter(name = "sortDirection", description = "sort direction", example = "ASC", required = true) @RequestParam String sortDirection)
+      @Parameter(
+              name = "page",
+              description = "what page of the data",
+              example = "0",
+              required = true)
+          @RequestParam
+          int page,
+      @Parameter(
+              name = "pageSize",
+              description = "size of each page",
+              example = "5",
+              required = true)
+          @RequestParam
+          int pageSize,
+      @Parameter(
+              name = "sortDirection",
+              description = "sort direction",
+              example = "ASC",
+              required = true)
+          @RequestParam
+          String sortDirection)
       throws JsonProcessingException {
     Iterable<User> users = null;
     List<String> allowedSortDirections = Arrays.asList("ASC", "DESC");

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UsersController.java
@@ -5,21 +5,29 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User information (admin only)")
 @RequestMapping("/api/admin/users")
 @RestController
 public class UsersController extends ApiController {
-  @Autowired UserRepository userRepository;
+  @Autowired
+  UserRepository userRepository;
 
-  @Autowired ObjectMapper mapper;
+  @Autowired
+  ObjectMapper mapper;
 
   @Operation(summary = "Get a list of all users")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -28,5 +36,33 @@ public class UsersController extends ApiController {
     Iterable<User> users = userRepository.findAll();
     String body = mapper.writeValueAsString(users);
     return ResponseEntity.ok().body(body);
+  }
+
+  @Operation(summary = "Get a list of all users with pages")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping(params = { "page", "pageSize", "sortDirection" })
+  public Iterable<User> usersPaged(
+      @Parameter(name = "page", description = "what page of the data", example = "0", required = true) @RequestParam int page,
+      @Parameter(name = "pageSize", description = "size of each page", example = "5", required = true) @RequestParam int pageSize,
+      @Parameter(name = "sortDirection", description = "sort direction", example = "ASC", required = true) @RequestParam String sortDirection)
+      throws JsonProcessingException {
+    Iterable<User> users = null;
+    List<String> allowedSortDirections = Arrays.asList("ASC", "DESC");
+    if (!allowedSortDirections.contains(sortDirection)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "%s is not a valid sort direction.  Valid values are %s",
+              sortDirection, allowedSortDirections));
+    }
+
+    Direction sortDirectionObject = Direction.ASC;
+    if (sortDirection.equals("DESC")) {
+      sortDirectionObject = Direction.DESC;
+    }
+
+    PageRequest pageRequest = PageRequest.of(page, pageSize, sortDirectionObject, "id");
+
+    users = userRepository.findAll(pageRequest);
+    return users;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/UserRepository.java
@@ -2,10 +2,14 @@ package edu.ucsb.cs156.courses.repositories;
 
 import edu.ucsb.cs156.courses.entities.User;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends CrudRepository<User, Long> {
   Optional<User> findByEmail(String email);
+
+  Page<User> findAll(Pageable pageable);
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UsersControllerTests.java
@@ -33,11 +33,9 @@ import org.springframework.test.web.servlet.MvcResult;
 @AutoConfigureDataJpa
 public class UsersControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UserRepository userRepository;
+  @MockBean UserRepository userRepository;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
   PageRequest pageRequest_0_5_ASC = PageRequest.of(0, 5, Direction.ASC, "id");
   PageRequest pageRequest_0_5_DESC = PageRequest.of(0, 5, Direction.DESC, "id");
@@ -47,13 +45,13 @@ public class UsersControllerTests extends ControllerTestCase {
     mockMvc.perform(get("/api/admin/users")).andExpect(status().is(403));
   }
 
-  @WithMockUser(roles = { "USER" })
+  @WithMockUser(roles = {"USER"})
   @Test
   public void users__user_logged_in() throws Exception {
     mockMvc.perform(get("/api/admin/users")).andExpect(status().is(403));
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
+  @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void users__admin_logged_in() throws Exception {
 
@@ -71,7 +69,8 @@ public class UsersControllerTests extends ControllerTestCase {
 
     // act
 
-    MvcResult response = mockMvc.perform(get("/api/admin/users")).andExpect(status().isOk()).andReturn();
+    MvcResult response =
+        mockMvc.perform(get("/api/admin/users")).andExpect(status().isOk()).andReturn();
 
     // assert
 
@@ -80,7 +79,7 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, responseString);
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
+  @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void usersPaged__admin_logged_in_asc() throws Exception {
     // arrange
@@ -94,29 +93,32 @@ public class UsersControllerTests extends ControllerTestCase {
 
     Page<User> testPage_0_5_ASC = new PageImpl<User>(expectedUsers, pageRequest_0_5_ASC, 3);
 
-    when(userRepository.findAll(pageRequest_0_5_ASC))
-        .thenReturn(testPage_0_5_ASC);
+    when(userRepository.findAll(pageRequest_0_5_ASC)).thenReturn(testPage_0_5_ASC);
     String expectedJson = objectMapper.writeValueAsString(testPage_0_5_ASC);
 
     // act
 
-    MvcResult response = mockMvc
-        .perform(get("/api/admin/users")
-            .param("page", "0")
-            .param("pageSize", "5")
-            .param("sortDirection", "ASC"))
-        .andExpect(status().isOk())
-        .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(
+                get("/api/admin/users")
+                    .param("page", "0")
+                    .param("pageSize", "5")
+                    .param("sortDirection", "ASC"))
+            .andExpect(status().isOk())
+            .andReturn();
 
     // assert
 
-    verify(userRepository, times(1)).findAll(org.springframework.data.domain.PageRequest.of(0, 5,
-        org.springframework.data.domain.Sort.Direction.ASC, "id"));
+    verify(userRepository, times(1))
+        .findAll(
+            org.springframework.data.domain.PageRequest.of(
+                0, 5, org.springframework.data.domain.Sort.Direction.ASC, "id"));
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
+  @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void usersPaged__admin_logged_in_desc() throws Exception {
     // arrange
@@ -130,44 +132,50 @@ public class UsersControllerTests extends ControllerTestCase {
 
     Page<User> testPage_0_5_DESC = new PageImpl<User>(expectedUsers, pageRequest_0_5_DESC, 3);
 
-    when(userRepository.findAll(pageRequest_0_5_DESC))
-        .thenReturn(testPage_0_5_DESC);
+    when(userRepository.findAll(pageRequest_0_5_DESC)).thenReturn(testPage_0_5_DESC);
     String expectedJson = objectMapper.writeValueAsString(testPage_0_5_DESC);
     // act
 
-    MvcResult response = mockMvc
-        .perform(get("/api/admin/users")
-            .param("page", "0")
-            .param("pageSize", "5")
-            .param("sortDirection", "DESC"))
-        .andExpect(status().isOk())
-        .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(
+                get("/api/admin/users")
+                    .param("page", "0")
+                    .param("pageSize", "5")
+                    .param("sortDirection", "DESC"))
+            .andExpect(status().isOk())
+            .andReturn();
 
     // assert
 
-    verify(userRepository, times(1)).findAll(org.springframework.data.domain.PageRequest.of(0, 5,
-        org.springframework.data.domain.Sort.Direction.DESC, "id"));
+    verify(userRepository, times(1))
+        .findAll(
+            org.springframework.data.domain.PageRequest.of(
+                0, 5, org.springframework.data.domain.Sort.Direction.DESC, "id"));
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
+  @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void usersPaged__fails_when_invalid_sortDirection() throws Exception {
 
-    MvcResult response = mockMvc
-        .perform(get("/api/admin/users")
-            .param("page", "0")
-            .param("pageSize", "5")
-            .param("sortDirection", "INVALID"))
-        .andExpect(status().isBadRequest())
-        .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(
+                get("/api/admin/users")
+                    .param("page", "0")
+                    .param("pageSize", "5")
+                    .param("sortDirection", "INVALID"))
+            .andExpect(status().isBadRequest())
+            .andReturn();
 
-    Map<String, String> expectedResponse = Map.of(
-        "message",
-        "INVALID is not a valid sort direction.  Valid values are [ASC, DESC]",
-        "type",
-        "IllegalArgumentException");
+    Map<String, String> expectedResponse =
+        Map.of(
+            "message",
+            "INVALID is not a valid sort direction.  Valid values are [ASC, DESC]",
+            "type",
+            "IllegalArgumentException");
 
     // assert
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UsersControllerTests.java
@@ -7,17 +7,24 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.ControllerTestCase;
 import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.testconfig.TestConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -26,20 +33,27 @@ import org.springframework.test.web.servlet.MvcResult;
 @AutoConfigureDataJpa
 public class UsersControllerTests extends ControllerTestCase {
 
-  @MockBean UserRepository userRepository;
+  @MockBean
+  UserRepository userRepository;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  PageRequest pageRequest_0_5_ASC = PageRequest.of(0, 5, Direction.ASC, "id");
+  PageRequest pageRequest_0_5_DESC = PageRequest.of(0, 5, Direction.DESC, "id");
 
   @Test
   public void users__logged_out() throws Exception {
     mockMvc.perform(get("/api/admin/users")).andExpect(status().is(403));
   }
 
-  @WithMockUser(roles = {"USER"})
+  @WithMockUser(roles = { "USER" })
   @Test
   public void users__user_logged_in() throws Exception {
     mockMvc.perform(get("/api/admin/users")).andExpect(status().is(403));
   }
 
-  @WithMockUser(roles = {"ADMIN", "USER"})
+  @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
   public void users__admin_logged_in() throws Exception {
 
@@ -57,13 +71,108 @@ public class UsersControllerTests extends ControllerTestCase {
 
     // act
 
-    MvcResult response =
-        mockMvc.perform(get("/api/admin/users")).andExpect(status().isOk()).andReturn();
+    MvcResult response = mockMvc.perform(get("/api/admin/users")).andExpect(status().isOk()).andReturn();
 
     // assert
 
     verify(userRepository, times(1)).findAll();
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void usersPaged__admin_logged_in_asc() throws Exception {
+    // arrange
+
+    User u1 = User.builder().id(1L).build();
+    User u2 = User.builder().id(2L).build();
+    User u = currentUserService.getCurrentUser().getUser();
+
+    ArrayList<User> expectedUsers = new ArrayList<>();
+    expectedUsers.addAll(Arrays.asList(u1, u2, u));
+
+    Page<User> testPage_0_5_ASC = new PageImpl<User>(expectedUsers, pageRequest_0_5_ASC, 3);
+
+    when(userRepository.findAll(pageRequest_0_5_ASC))
+        .thenReturn(testPage_0_5_ASC);
+    String expectedJson = objectMapper.writeValueAsString(testPage_0_5_ASC);
+
+    // act
+
+    MvcResult response = mockMvc
+        .perform(get("/api/admin/users")
+            .param("page", "0")
+            .param("pageSize", "5")
+            .param("sortDirection", "ASC"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // assert
+
+    verify(userRepository, times(1)).findAll(org.springframework.data.domain.PageRequest.of(0, 5,
+        org.springframework.data.domain.Sort.Direction.ASC, "id"));
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void usersPaged__admin_logged_in_desc() throws Exception {
+    // arrange
+
+    User u1 = User.builder().id(1L).build();
+    User u2 = User.builder().id(2L).build();
+    User u = currentUserService.getCurrentUser().getUser();
+
+    ArrayList<User> expectedUsers = new ArrayList<>();
+    expectedUsers.addAll(Arrays.asList(u1, u2, u));
+
+    Page<User> testPage_0_5_DESC = new PageImpl<User>(expectedUsers, pageRequest_0_5_DESC, 3);
+
+    when(userRepository.findAll(pageRequest_0_5_DESC))
+        .thenReturn(testPage_0_5_DESC);
+    String expectedJson = objectMapper.writeValueAsString(testPage_0_5_DESC);
+    // act
+
+    MvcResult response = mockMvc
+        .perform(get("/api/admin/users")
+            .param("page", "0")
+            .param("pageSize", "5")
+            .param("sortDirection", "DESC"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // assert
+
+    verify(userRepository, times(1)).findAll(org.springframework.data.domain.PageRequest.of(0, 5,
+        org.springframework.data.domain.Sort.Direction.DESC, "id"));
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void usersPaged__fails_when_invalid_sortDirection() throws Exception {
+
+    MvcResult response = mockMvc
+        .perform(get("/api/admin/users")
+            .param("page", "0")
+            .param("pageSize", "5")
+            .param("sortDirection", "INVALID"))
+        .andExpect(status().isBadRequest())
+        .andReturn();
+
+    Map<String, String> expectedResponse = Map.of(
+        "message",
+        "INVALID is not a valid sort direction.  Valid values are [ASC, DESC]",
+        "type",
+        "IllegalArgumentException");
+
+    // assert
+
+    String expectedResponseAsJson = objectMapper.writeValueAsString(expectedResponse);
+    String actualResponse = response.getResponse().getContentAsString();
+    assertEquals(expectedResponseAsJson, actualResponse);
   }
 }


### PR DESCRIPTION
Closes #43 
Added the backend endpoint so that a request to get all of the users would return a paged version, allowing the user to adjust how many users are shown on a single page and if it sorts ascending or descending. Tests were also added to ensure that the backend was implemented correctly.
[Link to Dev Development](https://courses-dev-joshuachu2004.dokku-03.cs.ucsb.edu/)
To Test:
Go to the Swagger API and find the Users Get. Input the Paged fields to return the users.