### PR TITLE
Fix faulty PersonalSection enrollCd selection

### DIFF
--- a/frontend/src/main/utils/PersonalSectionsUtils.jsx
+++ b/frontend/src/main/utils/PersonalSectionsUtils.jsx
@@ -10,7 +10,7 @@ export function cellToAxiosParamsDelete({ cell, psId }) {
     url: "/api/courses/user/psid",
     method: "DELETE",
     params: {
-      enrollCd: cell.row.original["classSections[0].enrollCode"],
+      enrollCd: cell.row.original.classSections[0].enrollCode,
       psId: psId,
     },
   };


### PR DESCRIPTION
The existing delete button for a Personal Schedule section does not work, and creates an error toast. This is because the code does not correctly find the required enrollCd parameter that needs to be passed to the backend API endpoint.

I fixed the Util responsible for making the API call to delete the personal section, ensuring that it correctly finds enrollCd.